### PR TITLE
Feature/add new skill

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
-"""
+'''
 Flask Application
-"""
+'''
 
 from flask import Flask, jsonify, request
 from models import Experience, Education, Skill
@@ -34,17 +34,17 @@ data = {
 
 @app.route("/test")
 def hello_world():
-    """
+    '''
     Returns a JSON test message
-    """
+    '''
     return jsonify({"message": "Hello, World!"})
 
 
 @app.route("/resume/experience", methods=["GET", "POST"])
 def experience():
-    """
+    '''
     Handle experience requests
-    """
+    '''
     if request.method == "GET":
         return jsonify()
 
@@ -56,9 +56,9 @@ def experience():
 
 @app.route("/resume/education", methods=["GET", "POST"])
 def education():
-    """
+    '''
     Handles education requests
-    """
+    '''
     if request.method == "GET":
         return jsonify({})
 
@@ -70,9 +70,9 @@ def education():
 
 @app.route("/resume/skill", methods=["GET", "POST"])
 def skill():
-    """
+    '''
     Handles Skill requests
-    """
+    '''
     if request.method == "GET":
         return jsonify({})
 

--- a/app.py
+++ b/app.py
@@ -1,6 +1,7 @@
-'''
+"""
 Flask Application
-'''
+"""
+
 from flask import Flask, jsonify, request
 from models import Experience, Education, Skill
 
@@ -8,73 +9,92 @@ app = Flask(__name__)
 
 data = {
     "experience": [
-        Experience("Software Developer",
-                   "A Cool Company",
-                   "October 2022",
-                   "Present",
-                   "Writing Python Code",
-                   "example-logo.png")
+        Experience(
+            "Software Developer",
+            "A Cool Company",
+            "October 2022",
+            "Present",
+            "Writing Python Code",
+            "example-logo.png",
+        )
     ],
     "education": [
-        Education("Computer Science",
-                  "University of Tech",
-                  "September 2019",
-                  "July 2022",
-                  "80%",
-                  "example-logo.png")
+        Education(
+            "Computer Science",
+            "University of Tech",
+            "September 2019",
+            "July 2022",
+            "80%",
+            "example-logo.png",
+        )
     ],
-    "skill": [
-        Skill("Python",
-              "1-2 Years",
-              "example-logo.png")
-    ]
+    "skill": [Skill("Python", "1-2 Years", "example-logo.png")],
 }
 
 
-@app.route('/test')
+@app.route("/test")
 def hello_world():
-    '''
+    """
     Returns a JSON test message
-    '''
+    """
     return jsonify({"message": "Hello, World!"})
 
 
-@app.route('/resume/experience', methods=['GET', 'POST'])
+@app.route("/resume/experience", methods=["GET", "POST"])
 def experience():
-    '''
+    """
     Handle experience requests
-    '''
-    if request.method == 'GET':
+    """
+    if request.method == "GET":
         return jsonify()
 
-    if request.method == 'POST':
+    if request.method == "POST":
         return jsonify({})
 
     return jsonify({})
 
-@app.route('/resume/education', methods=['GET', 'POST'])
+
+@app.route("/resume/education", methods=["GET", "POST"])
 def education():
-    '''
+    """
     Handles education requests
-    '''
-    if request.method == 'GET':
+    """
+    if request.method == "GET":
         return jsonify({})
 
-    if request.method == 'POST':
+    if request.method == "POST":
         return jsonify({})
 
     return jsonify({})
 
 
-@app.route('/resume/skill', methods=['GET', 'POST'])
+@app.route("/resume/skill", methods=["GET", "POST"])
 def skill():
-    '''
+    """
     Handles Skill requests
-    '''
-    if request.method == 'GET':
-        return jsonify({})
+    """
+    if request.method == "GET":
+        return jsonify([skill.__dict__ for skill in data["skill"]])
 
-    if request.method == 'POST':
-        return jsonify({})
+    if request.method == "POST":
+        json_data = request.json
+        try:
+            # extract the data from the request
+            name = json_data["name"]
+            proficiency = json_data["proficiency"]
+            logo = json_data["logo"]
 
-    return jsonify({})
+            new_skill = Skill(name, proficiency, logo)
+
+            data["skill"].append(new_skill)
+
+            # return the new skill and its ID
+            return jsonify(
+                {"id": len(data["skill"]) - 1, "skill": new_skill.__dict__}
+            ), 201
+        
+        except KeyError:
+            return jsonify({"error": "Invalid request"}), 400
+            
+        except TypeError as e:
+            return jsonify({"error": str(e)}), 400

--- a/app.py
+++ b/app.py
@@ -88,9 +88,9 @@ def skill():
 
             data["skill"].append(new_skill)
 
-            # return the new skill and its ID
+            # return ID of new skill
             return jsonify(
-                {"id": len(data["skill"]) - 1, "skill": new_skill.__dict__}
+                {"id": len(data["skill"]) - 1}
             ), 201
 
         except KeyError:

--- a/app.py
+++ b/app.py
@@ -1,7 +1,6 @@
 '''
 Flask Application
 '''
-
 from flask import Flask, jsonify, request
 from models import Experience, Education, Skill
 
@@ -9,30 +8,30 @@ app = Flask(__name__)
 
 data = {
     "experience": [
-        Experience(
-            "Software Developer",
-            "A Cool Company",
-            "October 2022",
-            "Present",
-            "Writing Python Code",
-            "example-logo.png",
-        )
+        Experience("Software Developer",
+                   "A Cool Company",
+                   "October 2022",
+                   "Present",
+                   "Writing Python Code",
+                   "example-logo.png")
     ],
     "education": [
-        Education(
-            "Computer Science",
-            "University of Tech",
-            "September 2019",
-            "July 2022",
-            "80%",
-            "example-logo.png",
-        )
+        Education("Computer Science",
+                  "University of Tech",
+                  "September 2019",
+                  "July 2022",
+                  "80%",
+                  "example-logo.png")
     ],
-    "skill": [Skill("Python", "1-2 Years", "example-logo.png")],
+    "skill": [
+        Skill("Python",
+              "1-2 Years",
+              "example-logo.png")
+    ]
 }
 
 
-@app.route("/test")
+@app.route('/test')
 def hello_world():
     '''
     Returns a JSON test message
@@ -40,43 +39,42 @@ def hello_world():
     return jsonify({"message": "Hello, World!"})
 
 
-@app.route("/resume/experience", methods=["GET", "POST"])
+@app.route('/resume/experience', methods=['GET', 'POST'])
 def experience():
     '''
     Handle experience requests
     '''
-    if request.method == "GET":
+    if request.method == 'GET':
         return jsonify()
 
-    if request.method == "POST":
+    if request.method == 'POST':
         return jsonify({})
 
     return jsonify({})
 
-
-@app.route("/resume/education", methods=["GET", "POST"])
+@app.route('/resume/education', methods=['GET', 'POST'])
 def education():
     '''
     Handles education requests
     '''
-    if request.method == "GET":
+    if request.method == 'GET':
         return jsonify({})
 
-    if request.method == "POST":
+    if request.method == 'POST':
         return jsonify({})
 
     return jsonify({})
 
 
-@app.route("/resume/skill", methods=["GET", "POST"])
+@app.route('/resume/skill', methods=['GET', 'POST'])
 def skill():
     '''
     Handles Skill requests
     '''
-    if request.method == "GET":
+    if request.method == 'GET':
         return jsonify({})
 
-    if request.method == "POST":
+    if request.method == 'POST':
         json_data = request.json
         try:
             # extract the data from the request

--- a/app.py
+++ b/app.py
@@ -74,7 +74,7 @@ def skill():
     Handles Skill requests
     """
     if request.method == "GET":
-        return jsonify([skill.__dict__ for skill in data["skill"]])
+        return jsonify({})
 
     if request.method == "POST":
         json_data = request.json

--- a/app.py
+++ b/app.py
@@ -92,9 +92,11 @@ def skill():
             return jsonify(
                 {"id": len(data["skill"]) - 1, "skill": new_skill.__dict__}
             ), 201
-        
+
         except KeyError:
             return jsonify({"error": "Invalid request"}), 400
-            
+
         except TypeError as e:
             return jsonify({"error": str(e)}), 400
+
+    return jsonify({})


### PR DESCRIPTION
## Description
This PR introduces a new endpoint for managing skills in the Resume API. The endpoint allows users to add a new skill to their resume by making a POST request to /resume/skill. The new skill is stored in memory and includes attributes such as:
 - `name`: The skill name (e.g., "JavaScript")
 - `proficiency`: The proficiency level (e.g., "Intermediate")
 - `logo`: A URL or file path for the logo representing the skill

## Changes Made:
 - Added a `POST /resume/skill` route to create a new skill.
 - Modified the in-memory database to store skills.
 - Implemented validation to ensure all required fields are provided.
 - Added appropriate response codes for success (201) and error handling (400).

## Testing:
 - Ensured that existing test cases for the Skills endoint passed successfully.

### Related Issue: #16 

## Responses

A sample POST request has the following format:
```json
{
    "name": "crocheting",
    "proficiency": "1-2.5 years",
    "logo": "crochet.png"
}
```
#### 200 OK
```json
{
    "id": 1
}
```
#### 400 BAD REQUEST
```json
{
  "error": "Invalid request"
}
```