### PR TITLE
feat: get /resume/experience/{#}

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,80 +1,90 @@
-'''
+"""
 Flask Application
-'''
+"""
+
 from flask import Flask, jsonify, request
-from models import Experience, Education, Skill
+
+from models import Education, Experience, Skill
 
 app = Flask(__name__)
 
 data = {
     "experience": [
-        Experience("Software Developer",
-                   "A Cool Company",
-                   "October 2022",
-                   "Present",
-                   "Writing Python Code",
-                   "example-logo.png")
+        Experience(
+            "Software Developer",
+            "A Cool Company",
+            "October 2022",
+            "Present",
+            "Writing Python Code",
+            "example-logo.png",
+        )
     ],
     "education": [
-        Education("Computer Science",
-                  "University of Tech",
-                  "September 2019",
-                  "July 2022",
-                  "80%",
-                  "example-logo.png")
+        Education(
+            "Computer Science",
+            "University of Tech",
+            "September 2019",
+            "July 2022",
+            "80%",
+            "example-logo.png",
+        )
     ],
-    "skill": [
-        Skill("Python",
-              "1-2 Years",
-              "example-logo.png")
-    ]
+    "skill": [Skill("Python", "1-2 Years", "example-logo.png")],
 }
 
 
-@app.route('/test')
+@app.route("/test")
 def hello_world():
-    '''
+    """
     Returns a JSON test message
-    '''
+    """
     return jsonify({"message": "Hello, World!"})
 
 
-@app.route('/resume/experience', methods=['GET', 'POST'])
-def experience():
-    '''
+@app.route("/resume/experience", methods=["GET", "POST"])
+@app.route("/resume/experience/<int:index>", methods=["GET"])
+def experience(index=None):
+    """
     Handle experience requests
-    '''
-    if request.method == 'GET':
-        return jsonify()
+    GET: Returns all experiences or a specific experience by index
+    POST: Creates a new experience
+    """
+    if request.method == "GET":
+        if index is not None:
+            try:
+                return jsonify(data["experience"][index])
+            except IndexError:
+                return jsonify({"error": "Experience not found"}), 404
 
-    if request.method == 'POST':
+    if request.method == "POST":
         return jsonify({})
 
-    return jsonify({})
+    return jsonify()
 
-@app.route('/resume/education', methods=['GET', 'POST'])
+
+@app.route("/resume/education", methods=["GET", "POST"])
 def education():
-    '''
+    """
     Handles education requests
-    '''
-    if request.method == 'GET':
+    """
+    if request.method == "GET":
         return jsonify({})
 
-    if request.method == 'POST':
+    if request.method == "POST":
         return jsonify({})
 
     return jsonify({})
 
 
-@app.route('/resume/skill', methods=['GET', 'POST'])
+@app.route("/resume/skill", methods=["GET", "POST"])
 def skill():
-    '''
+    """
     Handles Skill requests
-    '''
-    if request.method == 'GET':
+    """
+    if request.method == "GET":
         return jsonify({})
 
-    if request.method == 'POST':
+    if request.method == "POST":
         return jsonify({})
 
     return jsonify({})


### PR DESCRIPTION
## Description
- Resolves Issue #20 
- return a specific experience when a GET request is made with an index as an input
- experience returned in json format

## Testing
Endpoint:
 `GET http://127.0.0.1:5000/resume/experience/0` 

Expected Stub:
```json
{
    "company": "A Cool Company",
    "description": "Writing Python Code",
    "end_date": "Present",
    "logo": "example-logo.png",
    "start_date": "October 2022",
    "title": "Software Developer"
}
```

