### PR TITLE
Feat/get all experiences

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,11 +50,6 @@ def experience(index=None):
     POST: Creates a new experience
     """
     if request.method == "GET":
-        if index is not None:
-            try:
-                return jsonify(data["experience"][index])
-            except IndexError:
-                return jsonify({"error": "Experience not found"}), 404
         return jsonify(data["experience"])
 
     if request.method == "POST":

--- a/app.py
+++ b/app.py
@@ -55,6 +55,7 @@ def experience(index=None):
                 return jsonify(data["experience"][index])
             except IndexError:
                 return jsonify({"error": "Experience not found"}), 404
+        return jsonify(data["experience"])
 
     if request.method == "POST":
         return jsonify({})


### PR DESCRIPTION
> [!NOTE]  
> Should resolve PR #26 first

## Description
- Resolves Issue #21  
- return the experience list when a GET request is made
- return should be in a list format

## Testing
Endpoint:
 `GET http://127.0.0.1:5000/resume/experience` 

Expected Stub:
```json
{
    "company": "A Cool Company",
    "description": "Writing Python Code",
    "end_date": "Present",
    "logo": "example-logo.png",
    "start_date": "October 2022",
    "title": "Software Developer"
}
```

if you add more experiences with POST request, should be able to see all experiences

